### PR TITLE
Shortcut for taskbar hints, overlay optimizations and no hints suffle

### DIFF
--- a/src/HuntAndPeck/Services/HintLabelService.cs
+++ b/src/HuntAndPeck/Services/HintLabelService.cs
@@ -40,7 +40,7 @@ namespace HuntAndPeck.Services
             }
 
             // Note that shuffle is lazy evaluated. Sigh.
-            return hintStrings.Shuffle().ToList();
+            return hintStrings.ToList();
         }
 
         /// <summary>

--- a/src/HuntAndPeck/Services/Interfaces/IHintProviderService.cs
+++ b/src/HuntAndPeck/Services/Interfaces/IHintProviderService.cs
@@ -13,5 +13,7 @@ namespace HuntAndPeck.Services.Interfaces
         /// </summary>
         /// <returns>The hint session containing the available hints or null if there is no foreground window</returns>
         HintSession EnumHints();
+
+        HintSession EnumHints(IntPtr handle);
     }
 }

--- a/src/HuntAndPeck/Services/Interfaces/IKeyListenerService.cs
+++ b/src/HuntAndPeck/Services/Interfaces/IKeyListenerService.cs
@@ -21,8 +21,10 @@ namespace HuntAndPeck.Services.Interfaces
     internal interface IKeyListenerService
     {
         event EventHandler OnHotKeyActivated;
+        event EventHandler OnTaskbarHotKeyActivated;
         event EventHandler OnDebugHotKeyActivated;
 
+        HotKey TaskbarHotKey { get; set; }
         HotKey HotKey { get; set; }
         HotKey DebugHotKey { get; set; }
     }

--- a/src/HuntAndPeck/Services/KeyListenerService.cs
+++ b/src/HuntAndPeck/Services/KeyListenerService.cs
@@ -8,6 +8,7 @@ namespace HuntAndPeck.Services
     internal class KeyListenerService : Form, IKeyListenerService, IDisposable
     {
         public event EventHandler OnHotKeyActivated;
+        public event EventHandler OnTaskbarHotKeyActivated;
         public event EventHandler OnDebugHotKeyActivated;
 
         /// <summary>
@@ -16,6 +17,7 @@ namespace HuntAndPeck.Services
         private int _hotkeyIdCounter = 0;
 
         private HotKey _hotKey;
+        private HotKey _taskbarHotKey;
         private HotKey _debugHotKey;
 
         /// <summary>
@@ -50,6 +52,23 @@ namespace HuntAndPeck.Services
             }
         }
 
+        /// <summary>
+        /// Gets/sets the current task bar hotkey
+        /// </summary>
+        /// <remarks>Changing this will cause the current hotkey to be unregistered</remarks>
+        public HotKey TaskbarHotKey
+        {
+            get
+            {
+                return _taskbarHotKey;
+            }
+            set
+            {
+                _taskbarHotKey = value;
+                ReRegisterHotKey(_taskbarHotKey);
+            }
+        }
+
         public HotKey DebugHotKey
         {
             get
@@ -76,6 +95,15 @@ namespace HuntAndPeck.Services
                     OnHotKeyActivated != null)
                 {
                     OnHotKeyActivated(this, new EventArgs());
+                }
+
+                // Task bar hotkey
+                if (_taskbarHotKey != null &&
+                    e.Key == _taskbarHotKey.Keys &&
+                    e.Modifiers == _taskbarHotKey.Modifier &&
+                    OnHotKeyActivated != null)
+                {
+                    OnTaskbarHotKeyActivated(this, new EventArgs());
                 }
 
                 // Debug hotkey

--- a/src/HuntAndPeck/ViewModels/ShellViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/ShellViewModel.cs
@@ -38,6 +38,12 @@ namespace HuntAndPeck.ViewModels
                 Modifier = KeyModifier.Alt
             };
 
+            keyListener1.TaskbarHotKey = new HotKey
+            {
+                Keys = Keys.OemSemicolon,
+                Modifier = KeyModifier.Control
+            };
+
 #if DEBUG
             keyListener1.DebugHotKey = new HotKey
             {
@@ -47,6 +53,7 @@ namespace HuntAndPeck.ViewModels
 #endif
 
             keyListener1.OnHotKeyActivated += _keyListener_OnHotKeyActivated;
+            keyListener1.OnTaskbarHotKeyActivated += _keyListener_OnTaskbarHotKeyActivated;
             keyListener1.OnDebugHotKeyActivated += _keyListener_OnDebugHotKeyActivated;
 
             ShowOptionsCommand = new DelegateCommand(ShowOptions);
@@ -61,7 +68,17 @@ namespace HuntAndPeck.ViewModels
             var session = _hintProviderService.EnumHints();
             if (session != null)
             {
+                var vm = new OverlayViewModel(session, _hintLabelService);
+                _showOverlay(vm);
+            }
+        }
 
+        private void _keyListener_OnTaskbarHotKeyActivated(object sender, EventArgs e)
+        {
+            var taskbarHWnd = User32.FindWindow("Shell_traywnd", "");
+            var session = _hintProviderService.EnumHints(taskbarHWnd);
+            if (session != null)
+            {
                 var vm = new OverlayViewModel(session, _hintLabelService);
                 _showOverlay(vm);
             }

--- a/src/HuntAndPeck/Views/OverlayView.xaml
+++ b/src/HuntAndPeck/Views/OverlayView.xaml
@@ -5,6 +5,7 @@
     xmlns:local="clr-namespace:HuntAndPeck.Views"
     WindowStyle="None"
     ResizeMode="NoResize"
+    ShowInTaskbar="False"
     AllowsTransparency="True"
     Topmost="True"
     FocusManager.FocusedElement="{Binding ElementName=MatchStringControl}"

--- a/src/HuntAndPeck/Views/OverlayView.xaml
+++ b/src/HuntAndPeck/Views/OverlayView.xaml
@@ -45,11 +45,11 @@
                     <Grid>
                         <Rectangle Width="{Binding Hint.BoundingRectangle.Width}" Height="{Binding Hint.BoundingRectangle.Height}" Stroke="Red" StrokeDashArray="1 2">
                             <Rectangle.Fill>
-                                <SolidColorBrush Color="Yellow" Opacity="0.2" />
+                                <SolidColorBrush Color="Yellow" Opacity="0.05" />
                             </Rectangle.Fill>
                         </Rectangle>
                         <Viewbox StretchDirection="DownOnly" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="1 1 0 0" Width="{Binding Hint.BoundingRectangle.Width}" Height="{Binding Hint.BoundingRectangle.Height}">
-                            <TextBlock Text="{Binding Label}" FontFamily="Courier New" FontWeight="ExtraBold" FontSize="16" Style="{StaticResource HintStyle}">
+                            <TextBlock Text="{Binding Label}" FontFamily="Courier New" FontWeight="ExtraBold" FontSize="14" Style="{StaticResource HintStyle}">
                             </TextBlock>
                         </Viewbox>
                     </Grid>
@@ -59,3 +59,4 @@
         </Grid>
 </local:ForegroundWindow>
 
+    

--- a/src/HuntAndPeck/Views/OverlayView.xaml
+++ b/src/HuntAndPeck/Views/OverlayView.xaml
@@ -24,7 +24,7 @@
         <SolidColorBrush Color="Transparent" />
     </local:ForegroundWindow.Background>
     <Grid x:Name="layoutGrid">
-        <TextBox x:Name="MatchStringControl" Text="{Binding MatchString, UpdateSourceTrigger=PropertyChanged, Mode=OneWayToSource}" VerticalAlignment="Bottom" Background="Black" Foreground="White" />
+        <TextBox x:Name="MatchStringControl" Text="{Binding MatchString, UpdateSourceTrigger=PropertyChanged, Mode=OneWayToSource}" Width="50" VerticalAlignment="Bottom" Background="Transparent" Foreground="White" />
         <ItemsControl ItemsSource="{Binding Hints}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/src/NativeMethods/User32.cs
+++ b/src/NativeMethods/User32.cs
@@ -37,5 +37,8 @@ namespace HuntAndPeck.NativeMethods
 
         [DllImport("user32.dll")]
         public static extern IntPtr SetFocus(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
     }
 }


### PR DESCRIPTION
- Added Ctrl+; as a shortcut to display hints for windows taskbar, regardless of the foreground window.
- Overlay view now does not show up on windows taskbar
- Made the hint input smaller and transparent. Especially important when displaying hints on top of windows taskbar. It was hiding half of the taskbar.
- Removed shuffling of shortcuts. Why was that there anyway? It's much better to get the same shortcuts when displaying hints multiple times for the same UI.