### PR TITLE
Improve setting foreground window

### DIFF
--- a/src/HuntAndPeck/Views/ForegroundWindow.cs
+++ b/src/HuntAndPeck/Views/ForegroundWindow.cs
@@ -21,7 +21,10 @@ namespace HuntAndPeck.Views
             {
                 // Always want this on top. SetForegroundWindow has a few conditions:
                 // https://msdn.microsoft.com/en-us/library/ms633539(VS.85).aspx
-                ForceForeground();
+                if (!User32.SetForegroundWindow(new WindowInteropHelper(this).Handle))
+                {
+                    ForceForeground();
+                }
                 _initialized = true;
             }
             base.OnRender(drawingContext);

--- a/src/NativeMethods/User32.cs
+++ b/src/NativeMethods/User32.cs
@@ -30,6 +30,9 @@ namespace HuntAndPeck.NativeMethods
         public static extern uint GetWindowThreadProcessId(IntPtr hWnd, IntPtr ProcessId);
 
         [DllImport("user32.dll")]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
         public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
 
         [DllImport("user32.dll")]


### PR DESCRIPTION
If the user pressed the shortcut, it is `hap.exe` which received the last input event, so `SetForegroundWindow()` should work according to [Microsoft](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow). If `SetForegroundWindow()` fails, we just use `ForceForeground()`. I don't remember exactly when, I have seen `ForceForeground()` fails but `SetForegroundWindow()` succeeds.