### PR TITLE
Add headless tray mode

### DIFF
--- a/src/HuntAndPeck/App.xaml.cs
+++ b/src/HuntAndPeck/App.xaml.cs
@@ -3,6 +3,7 @@ using HuntAndPeck.ViewModels;
 using System.Linq;
 using HuntAndPeck.Services;
 using HuntAndPeck.Views;
+using HuntAndPeck.NativeMethods;
 
 namespace HuntAndPeck
 {
@@ -50,6 +51,17 @@ namespace HuntAndPeck
             {
                 // support headless mode
                 var session = _hintProviderService.EnumHints();
+                var overlayWindow = new OverlayView()
+                {
+                    DataContext = new OverlayViewModel(session, _hintLabelService)
+                };
+                overlayWindow.Show();
+            }
+            else if (e.Args.Contains("/tray"))
+            {
+                // support headless tray mode
+                var taskbarHWnd = User32.FindWindow("Shell_traywnd", "");
+                var session = _hintProviderService.EnumHints(taskbarHWnd);
                 var overlayWindow = new OverlayView()
                 {
                     DataContext = new OverlayViewModel(session, _hintLabelService)


### PR DESCRIPTION
This adds headless mode `/tray` for tray. `/hint` executes the current focus window.

The motivation behind this PR. Normally this would be called through keyboard shortcuts however the default hunt-and-peck shortcuts can conflict with certain applications. Calling it through the command line eliminates this issue however it is a bit of a brute force solution.