### PR TITLE
Define keyboard shortcuts on launch by XML file in %AppData%, and install with WiX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,11 @@ Or in tray mode with
 hap.exe /tray
 ```
 
+## To customize
+
+Hotkeys can be found at and modified at %AppData%\\Local\\HuntAndPeck\\[VERSION NUMBER]\\user.config.xml
+
+Please supply a [key code](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=windowsdesktop-6.0) and one or more modifier keys Alt, Control, Shift, Windows.  Seperate them with a comma as seen here.  
+
 # Supported Elements
 Only UI Automation elements with "Invoke" patterns are supported (and displayed).

--- a/src/HuntAndPeck.sln
+++ b/src/HuntAndPeck.sln
@@ -25,9 +25,7 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/HuntAndPeck.sln
+++ b/src/HuntAndPeck.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.15
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32126.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeMethods", "NativeMethods\NativeMethods.csproj", "{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}"
 EndProject
@@ -20,26 +20,52 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HuntAndPeck.Tests", "HuntAndPeck.Tests\HuntAndPeck.Tests.csproj", "{043555C4-568F-4ECD-B064-6C3DC1EA3124}"
 EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "MSI", "MSI\MSI.wixproj", "{44C8FB68-8EB3-4872-8163-3370239215F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Debug|x86.Build.0 = Debug|Any CPU
 		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Release|x86.ActiveCfg = Release|Any CPU
+		{556F1A03-8752-4C41-BB29-E7FA7FF68CD9}.Release|x86.Build.0 = Release|Any CPU
 		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Debug|x86.Build.0 = Debug|Any CPU
 		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Release|x86.ActiveCfg = Release|Any CPU
+		{D9A0620D-D51F-4FCF-821E-AADD36230830}.Release|x86.Build.0 = Release|Any CPU
 		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Debug|x86.Build.0 = Debug|Any CPU
 		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Release|Any CPU.Build.0 = Release|Any CPU
+		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Release|x86.ActiveCfg = Release|Any CPU
+		{043555C4-568F-4ECD-B064-6C3DC1EA3124}.Release|x86.Build.0 = Release|Any CPU
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Debug|x86.ActiveCfg = Debug|x86
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Debug|x86.Build.0 = Debug|x86
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Release|Any CPU.ActiveCfg = Release|x86
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Release|Any CPU.Build.0 = Release|x86
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Release|x86.ActiveCfg = Release|x86
+		{44C8FB68-8EB3-4872-8163-3370239215F9}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F2FFC432-ACBD-4672-B19D-A030BA8B85F2}
 	EndGlobalSection
 EndGlobal

--- a/src/HuntAndPeck/App.config
+++ b/src/HuntAndPeck/App.config
@@ -1,6 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="HuntAndPeck.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+    <userSettings>
+        <HuntAndPeck.Properties.Settings>
+            <setting name="myModifiers" serializeAs="String">
+                <value>Alt</value>
+            </setting>
+            <setting name="myTaskbarModifiers" serializeAs="String">
+                <value>Control</value>
+            </setting>
+            <setting name="myDebugModifiers" serializeAs="String">
+                <value>Alt, Shift</value>
+            </setting>
+            <setting name="myHotkey" serializeAs="String">
+                <value>Oem1</value>
+            </setting>
+            <setting name="myTaskbarHotkey" serializeAs="String">
+                <value>Oem1</value>
+            </setting>
+            <setting name="myDebugHotkey" serializeAs="String">
+                <value>Oem1</value>
+            </setting>
+        </HuntAndPeck.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/src/HuntAndPeck/App.config
+++ b/src/HuntAndPeck/App.config
@@ -10,13 +10,22 @@
     </startup>
     <userSettings>
         <HuntAndPeck.Properties.Settings>
-            <setting name="myHotkey" serializeAs="String">
-                <value>Oem1</value>
+            <setting name="myModifiers" serializeAs="String">
+                <value>Alt</value>
+            </setting>
+            <setting name="myTaskbarModifiers" serializeAs="String">
+                <value>Control</value>
+            </setting>
+            <setting name="myDebugModifiers" serializeAs="String">
+                <value>Alt, Shift</value>
             </setting>
             <setting name="myTaskbarHotkey" serializeAs="String">
                 <value>Oem1</value>
             </setting>
             <setting name="myDebugHotkey" serializeAs="String">
+                <value>Oem1</value>
+            </setting>
+            <setting name="myHotkey" serializeAs="String">
                 <value>Oem1</value>
             </setting>
         </HuntAndPeck.Properties.Settings>

--- a/src/HuntAndPeck/App.config
+++ b/src/HuntAndPeck/App.config
@@ -10,15 +10,6 @@
     </startup>
     <userSettings>
         <HuntAndPeck.Properties.Settings>
-            <setting name="myModifiers" serializeAs="String">
-                <value>Alt</value>
-            </setting>
-            <setting name="myTaskbarModifiers" serializeAs="String">
-                <value>Control</value>
-            </setting>
-            <setting name="myDebugModifiers" serializeAs="String">
-                <value>Alt, Shift</value>
-            </setting>
             <setting name="myHotkey" serializeAs="String">
                 <value>Oem1</value>
             </setting>

--- a/src/HuntAndPeck/HuntAndPeck.csproj
+++ b/src/HuntAndPeck/HuntAndPeck.csproj
@@ -231,8 +231,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
+    <PreBuildEvent>taskkill /f /fi "pid gt 0" /im hap.exe</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/HuntAndPeck/HuntAndPeck.csproj
+++ b/src/HuntAndPeck/HuntAndPeck.csproj
@@ -15,6 +15,7 @@
     <WarningLevel>4</WarningLevel>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -27,7 +28,6 @@
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/src/HuntAndPeck/HuntAndPeck.csproj
+++ b/src/HuntAndPeck/HuntAndPeck.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{D9A0620D-D51F-4FCF-821E-AADD36230830}</ProjectGuid>
     <OutputType>WinExe</OutputType>
@@ -58,6 +59,7 @@
       <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.5\lib\net45\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -95,6 +97,16 @@
     <Compile Include="Models\UiAutomationInvokeHint.cs" />
     <Compile Include="Models\UiAutomationSelectHint.cs" />
     <Compile Include="Models\UiAutomationToggleHint.cs" />
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
     <Compile Include="Services\HintLabelService.cs" />
     <Compile Include="Services\Interfaces\IDebugHintProviderService.cs" />
     <Compile Include="Services\Interfaces\IHintLabelService.cs" />
@@ -105,6 +117,7 @@
     </Compile>
     <Compile Include="Services\UiAutomationPatternIds.cs" />
     <Compile Include="Services\UiAutomationHintProviderService.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="SingleLaunchMutex.cs" />
     <Compile Include="ViewModels\DebugHintViewModel.cs" />
     <Compile Include="ViewModels\DebugOverlayViewModel.cs" />
@@ -132,18 +145,9 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
+      <SubType>Designer</SubType>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="packages.config" />

--- a/src/HuntAndPeck/Properties/AssemblyInfo.cs
+++ b/src/HuntAndPeck/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;

--- a/src/HuntAndPeck/Properties/Resources.Designer.cs
+++ b/src/HuntAndPeck/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace HuntAndPeck.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/HuntAndPeck/Properties/Settings.Designer.cs
+++ b/src/HuntAndPeck/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace HuntAndPeck.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -20,6 +20,78 @@ namespace HuntAndPeck.Properties {
         public static Settings Default {
             get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Alt")]
+        public global::HuntAndPeck.NativeMethods.KeyModifier myModifiers {
+            get {
+                return ((global::HuntAndPeck.NativeMethods.KeyModifier)(this["myModifiers"]));
+            }
+            set {
+                this["myModifiers"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Control")]
+        public global::HuntAndPeck.NativeMethods.KeyModifier myTaskbarModifiers {
+            get {
+                return ((global::HuntAndPeck.NativeMethods.KeyModifier)(this["myTaskbarModifiers"]));
+            }
+            set {
+                this["myTaskbarModifiers"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Alt, Shift")]
+        public global::HuntAndPeck.NativeMethods.KeyModifier myDebugModifiers {
+            get {
+                return ((global::HuntAndPeck.NativeMethods.KeyModifier)(this["myDebugModifiers"]));
+            }
+            set {
+                this["myDebugModifiers"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Oem1")]
+        public global::System.Windows.Forms.Keys myHotkey {
+            get {
+                return ((global::System.Windows.Forms.Keys)(this["myHotkey"]));
+            }
+            set {
+                this["myHotkey"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Oem1")]
+        public global::System.Windows.Forms.Keys myTaskbarHotkey {
+            get {
+                return ((global::System.Windows.Forms.Keys)(this["myTaskbarHotkey"]));
+            }
+            set {
+                this["myTaskbarHotkey"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Oem1")]
+        public global::System.Windows.Forms.Keys myDebugHotkey {
+            get {
+                return ((global::System.Windows.Forms.Keys)(this["myDebugHotkey"]));
+            }
+            set {
+                this["myDebugHotkey"] = value;
             }
         }
     }

--- a/src/HuntAndPeck/Properties/Settings.Designer.cs
+++ b/src/HuntAndPeck/Properties/Settings.Designer.cs
@@ -62,18 +62,6 @@ namespace HuntAndPeck.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Oem1")]
-        public global::System.Windows.Forms.Keys myHotkey {
-            get {
-                return ((global::System.Windows.Forms.Keys)(this["myHotkey"]));
-            }
-            set {
-                this["myHotkey"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("Oem1")]
         public global::System.Windows.Forms.Keys myTaskbarHotkey {
             get {
                 return ((global::System.Windows.Forms.Keys)(this["myTaskbarHotkey"]));
@@ -92,6 +80,17 @@ namespace HuntAndPeck.Properties {
             }
             set {
                 this["myDebugHotkey"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Windows.Forms.Keys myHotkey {
+            get {
+                return ((global::System.Windows.Forms.Keys)(this["myHotkey"]));
+            }
+            set {
+                this["myHotkey"] = value;
             }
         }
     }

--- a/src/HuntAndPeck/Properties/Settings.settings
+++ b/src/HuntAndPeck/Properties/Settings.settings
@@ -1,7 +1,24 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="HuntAndPeck.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="myModifiers" Type="HuntAndPeck.NativeMethods.KeyModifier" Scope="User">
+      <Value Profile="(Default)">Alt</Value>
+    </Setting>
+    <Setting Name="myTaskbarModifiers" Type="HuntAndPeck.NativeMethods.KeyModifier" Scope="User">
+      <Value Profile="(Default)">Control</Value>
+    </Setting>
+    <Setting Name="myDebugModifiers" Type="HuntAndPeck.NativeMethods.KeyModifier" Scope="User">
+      <Value Profile="(Default)">Alt, Shift</Value>
+    </Setting>
+    <Setting Name="myHotkey" Type="System.Windows.Forms.Keys" Scope="User">
+      <Value Profile="(Default)">Oem1</Value>
+    </Setting>
+    <Setting Name="myTaskbarHotkey" Type="System.Windows.Forms.Keys" Scope="User">
+      <Value Profile="(Default)">Oem1</Value>
+    </Setting>
+    <Setting Name="myDebugHotkey" Type="System.Windows.Forms.Keys" Scope="User">
+      <Value Profile="(Default)">Oem1</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/src/HuntAndPeck/Properties/Settings.settings
+++ b/src/HuntAndPeck/Properties/Settings.settings
@@ -11,13 +11,13 @@
     <Setting Name="myDebugModifiers" Type="HuntAndPeck.NativeMethods.KeyModifier" Scope="User">
       <Value Profile="(Default)">Alt, Shift</Value>
     </Setting>
-    <Setting Name="myHotkey" Type="System.Windows.Forms.Keys" Scope="User">
-      <Value Profile="(Default)">Oem1</Value>
-    </Setting>
     <Setting Name="myTaskbarHotkey" Type="System.Windows.Forms.Keys" Scope="User">
       <Value Profile="(Default)">Oem1</Value>
     </Setting>
     <Setting Name="myDebugHotkey" Type="System.Windows.Forms.Keys" Scope="User">
+      <Value Profile="(Default)">Oem1</Value>
+    </Setting>
+    <Setting Name="myHotkey" GenerateDefaultValueInCode="false" Type="System.Windows.Forms.Keys" Scope="User">
       <Value Profile="(Default)">Oem1</Value>
     </Setting>
   </Settings>

--- a/src/HuntAndPeck/Services/HintLabelService.cs
+++ b/src/HuntAndPeck/Services/HintLabelService.cs
@@ -22,8 +22,8 @@ namespace HuntAndPeck.Services
             {
                 return hintStrings;
             }
-
-            var hintCharacters = new[] { 'S', 'A', 'D', 'F', 'J', 'K', 'L', 'E', 'W', 'C', 'M', 'P', 'G', 'H' };
+            
+            var hintCharacters = new[] { 'S', 'A', 'D', 'F', 'J', 'K', 'L', 'E', 'I', 'B', 'W', 'O', 'T', 'U', 'Y', 'R', 'Q', 'C', 'V', 'N', 'C', 'M', 'P', 'G', 'H', 'X', 'Z' }; // #todo consider adding []\;',./`
             var digitsNeeded = (int)Math.Ceiling(Math.Log(hintCount) / Math.Log(hintCharacters.Length));
 
             var wholeHintCount = (int)Math.Pow(hintCharacters.Length, digitsNeeded);

--- a/src/HuntAndPeck/Settings.cs
+++ b/src/HuntAndPeck/Settings.cs
@@ -1,0 +1,28 @@
+﻿namespace HuntAndPeck.Properties {
+    
+    
+    // This class allows you to handle specific events on the settings class:
+    //  The SettingChanging event is raised before a setting's value is changed.
+    //  The PropertyChanged event is raised after a setting's value is changed.
+    //  The SettingsLoaded event is raised after the setting values are loaded.
+    //  The SettingsSaving event is raised before the setting values are saved.
+    internal sealed partial class Settings {
+        
+        public Settings() {
+            // // To add event handlers for saving and changing settings, uncomment the lines below:
+            //
+            this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // Add code to handle the SettingChangingEvent event here.
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // Add code to handle the SettingsSaving event here.
+        }
+    }
+}

--- a/src/HuntAndPeck/ViewModels/ShellViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/ShellViewModel.cs
@@ -4,6 +4,10 @@ using HuntAndPeck.NativeMethods;
 using HuntAndPeck.Services.Interfaces;
 using Application = System.Windows.Application;
 
+//attempt to have settings not just in a file, but in AppData
+using System.Configuration;
+using System.Collections.Specialized;
+
 namespace HuntAndPeck.ViewModels
 {
     internal class ShellViewModel
@@ -32,15 +36,13 @@ namespace HuntAndPeck.ViewModels
             _hintProviderService = hintProviderService;
             _debugHintProviderService = debugHintProviderService;
 
-            //get hotkeys from AppData if possible. If not available, then from local directory
+            //get hotkeys from AppData if possible. If not available, then from local directory            
 
             keyListener1.HotKey = new HotKey
             {                
                 Keys = Properties.Settings.Default.myHotkey,
                 Modifier = Properties.Settings.Default.myModifiers
             };
-
-            Properties.Settings.Default.Save();
 
             keyListener1.TaskbarHotKey = new HotKey
             {
@@ -55,6 +57,7 @@ namespace HuntAndPeck.ViewModels
                 Modifier = Properties.Settings.Default.myDebugModifiers
             };
 #endif
+            Properties.Settings.Default.Save();
 
             keyListener1.OnHotKeyActivated += _keyListener_OnHotKeyActivated;
             keyListener1.OnTaskbarHotKeyActivated += _keyListener_OnTaskbarHotKeyActivated;

--- a/src/HuntAndPeck/ViewModels/ShellViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/ShellViewModel.cs
@@ -32,11 +32,15 @@ namespace HuntAndPeck.ViewModels
             _hintProviderService = hintProviderService;
             _debugHintProviderService = debugHintProviderService;
 
+            //get hotkeys from AppData if possible. If not available, then from local directory
+
             keyListener1.HotKey = new HotKey
             {                
                 Keys = Properties.Settings.Default.myHotkey,
                 Modifier = Properties.Settings.Default.myModifiers
-            };            
+            };
+
+            Properties.Settings.Default.Save();
 
             keyListener1.TaskbarHotKey = new HotKey
             {

--- a/src/HuntAndPeck/ViewModels/ShellViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/ShellViewModel.cs
@@ -33,22 +33,22 @@ namespace HuntAndPeck.ViewModels
             _debugHintProviderService = debugHintProviderService;
 
             keyListener1.HotKey = new HotKey
-            {
-                Keys = Keys.OemSemicolon,
-                Modifier = KeyModifier.Alt
-            };
+            {                
+                Keys = Properties.Settings.Default.myHotkey,
+                Modifier = Properties.Settings.Default.myModifiers
+            };            
 
             keyListener1.TaskbarHotKey = new HotKey
             {
-                Keys = Keys.OemSemicolon,
-                Modifier = KeyModifier.Control
+                Keys = Properties.Settings.Default.myTaskbarHotkey,
+                Modifier = Properties.Settings.Default.myTaskbarModifiers
             };
 
 #if DEBUG
             keyListener1.DebugHotKey = new HotKey
             {
-                Keys = Keys.OemSemicolon,
-                Modifier = KeyModifier.Alt | KeyModifier.Shift
+                Keys = Properties.Settings.Default.myDebugHotkey,
+                Modifier = Properties.Settings.Default.myDebugModifiers
             };
 #endif
 
@@ -62,6 +62,11 @@ namespace HuntAndPeck.ViewModels
 
         public DelegateCommand ShowOptionsCommand { get; }
         public DelegateCommand ExitCommand { get; }
+
+        private void refresh_Hotkeys() // invert control to inject hotkeys from xml file
+        {
+            //ShellViewModel.setHotkey();
+        }
 
         private void _keyListener_OnHotKeyActivated(object sender, EventArgs e)
         {
@@ -104,5 +109,5 @@ namespace HuntAndPeck.ViewModels
             var vm = new OptionsViewModel();
             _showOptions(vm);
         }
-    }
+    }    
 }

--- a/src/HuntAndPeck/ViewModels/ShellViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/ShellViewModel.cs
@@ -56,8 +56,7 @@ namespace HuntAndPeck.ViewModels
                 Keys = Properties.Settings.Default.myDebugHotkey,
                 Modifier = Properties.Settings.Default.myDebugModifiers
             };
-#endif
-            Properties.Settings.Default.Save();
+#endif      
 
             keyListener1.OnHotKeyActivated += _keyListener_OnHotKeyActivated;
             keyListener1.OnTaskbarHotKeyActivated += _keyListener_OnTaskbarHotKeyActivated;

--- a/src/HuntAndPeck/Views/ShellView.xaml
+++ b/src/HuntAndPeck/Views/ShellView.xaml
@@ -9,9 +9,9 @@
                     MenuActivation="LeftOrRightClick">
         <tb:TaskbarIcon.ContextMenu>
             <ContextMenu>
-                <MenuItem Header="Options" Command="{Binding ShowOptionsCommand}"></MenuItem>
+                <MenuItem Header="O_ptions" Command="{Binding ShowOptionsCommand}"></MenuItem>
                 <Separator />
-                <MenuItem Header="Exit" Command="{Binding ExitCommand}"></MenuItem>
+                <MenuItem Header="E_xit" Command="{Binding ExitCommand}"></MenuItem>
             </ContextMenu>
         </tb:TaskbarIcon.ContextMenu>
     </tb:TaskbarIcon>

--- a/src/MSI/MSI.wixproj
+++ b/src/MSI/MSI.wixproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>44c8fb68-8eb3-4872-8163-3370239215f9</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>MSI</OutputName>
+    <OutputType>Package</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Product.wxs" />
+  </ItemGroup>
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+  </Target>
+  <!--
+	To modify your build process, add your task inside one of the targets below and uncomment it.
+	Other similar extension points exist, see Wix.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -2,19 +2,22 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Name="HuntAndPeck" Language="1033" Version="1.0.0.0" Manufacturer="HuntAndPeck" UpgradeCode="e47f0958-e969-481b-af24-6df49fd45ca7">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+    <!--Uninstall Icon-->
+    <Icon Id="icon.ico" SourceFile="..\HuntAndPeck\Resources\originalbird.ico"/>
+    <Property Id="ARPPRODUCTICON" Value="icon.ico"/>
+    <Property Id='P.REMOVEDATAFOLDER' Secure='yes' />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate />
 
     <Feature Id="ProductFeature" Title="HuntAndPeck" Level="1">
-      <?if $(sys.BUILDARCH)=x86?>
-      <!--<ComponentGroupRef Id="StartMenuComponents"/> -->
+      <?if $(sys.BUILDARCH)=x86?>      
       <!--#todo-->
       <!--<ComponentGroupRef Id="Settings"/> -->
-      <!--#todo-->
       <?endif ?>
+      <ComponentGroupRef Id="StartMenuComponents"/>
       <ComponentGroupRef Id="Componentsx86" />
-      <ComponentGroupRef Id="Componentsx64"/>
+      <ComponentGroupRef Id="Componentsx64"/>      
     </Feature>
 
     <InstallExecuteSequence>
@@ -27,9 +30,16 @@
   <!--Directory Structure-->
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
+      <!--Start Menu Shortcut-->
+      <Directory Id="ProgramMenuFolder">
+        <Directory Id="MyShortcutsDir" Name="HuntAndPeck">
+        </Directory>
+      </Directory>      
+      <!--x86 Version-->
       <Directory Id="ProgramFilesFolder">
         <Directory Id="INSTALLFOLDERx86" Name="HuntAndPeck" />
       </Directory>
+      <!--x64 Version-->
       <Directory Id="ProgramFiles64Folder">
         <Directory Id="INSTALLFOLDERx64" Name="HuntAndPeck">
         </Directory>
@@ -38,13 +48,17 @@
   </Fragment>
 
   <Fragment>
+    <!--x86 Version-->
     <ComponentGroup Id="Componentsx86" Directory="INSTALLFOLDERx86">
+      <!--Main HAP Executable-->
       <Component Id="HAPx86" Guid="{36C49F2D-4984-48DC-9EFF-B7FDA3BEFDC2}">
         <File Id="HAPx86EXE" Source="..\HuntAndPeck\bin\Release\hap.exe" KeyPath="yes"/>
       </Component>
+      <!--Default Configuration File-->
       <Component Id="CONFIGx86" Guid="{C26B82BA-5932-45B0-9C04-45F4DB217CDA}">
         <File Id="HAPx86CONFIG" Source="..\HuntAndPeck\bin\Release\hap.exe.config" KeyPath="yes"/>
       </Component>
+      <!--DLLs-->
       <Component Id="TASKBARNOTIFICATIONx86" Guid="{A4EBC175-73E2-4E73-A36B-40150F8E5F1C}">
         <File Id="TASKBARNOTIFICATIONx86DLL" Source="..\HuntAndPeck\bin\Release\Hardcodet.Wpf.TaskbarNotification.dll" KeyPath="yes"/>
       </Component>
@@ -54,8 +68,31 @@
       <Component Id="UIAUTOMATIONCLIENTx86" Guid="{1FB81928-DF06-4A87-A2B1-495F0A85A66B}">
         <File Id="UIAUTOMATIONCLIENTx86DLL" Source="..\HuntAndPeck\bin\Release\Interop.UIAutomationClient.dll" KeyPath="yes"/>
       </Component>
+      <!--ReadMe, from MSI WiX folder-->
+      <Component Id="README" Guid="{02752B18-74D4-4272-B279-B3517B8056FB}">
+        <File Id="READMETXT" Source="ReadMe.txt" KeyPath="yes"/>
+      </Component>
     </ComponentGroup>
+    <!--x64 Version-->
     <ComponentGroup Id="Componentsx64" Directory="INSTALLFOLDERx64">
+    </ComponentGroup>
+    <!--Start Menu Folder-->
+    <ComponentGroup Id="StartMenuComponents" Directory="MyShortcutsDir">
+      <Component Id="CMP_HapShortcut" Guid="{1B27CCC7-D53F-464E-A5CB-4BCDD3172D04}">
+        <Shortcut Id="HapShortcut" Name="HuntAndPeck" Description="Hunt and Peck main application" Target="[IMEINSTALLFOLDERx86]hap.exe" Icon="icon.ico"/>
+        <RegistryValue Root="HKCU" Key="Software\HuntAndPeck" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+      </Component>
+
+      <!--#todo uninstall shortcut-->
+
+      <!--#todo have command line call to hap.exe to a function that exposes the location of Properties.Settings.Default and create a shortcut in the Start Menu folder to it-->
+
+      <Component Id="CMP_DocumentationShortcut" Guid="{9F10ECAC-B507-4DD0-A7FA-FD6A8B3CB6C5}">
+        <Shortcut Id="ReadMeShortcut" Name="ReadMe" Description="Read this please" Target="[IMEINSTALLFOLDERx86]ReadMe.txt" />
+        
+        <RemoveFolder Id="RemoveMyShortcutsDir" On="uninstall"/>
+        <RegistryValue Root="HKCU" Key="Software\HuntAndPeck" Name="installed" Type="integer" Value="1" KeyPath="yes"/>        
+      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/MSI/Product.wxs
+++ b/src/MSI/Product.wxs
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Name="HuntAndPeck" Language="1033" Version="1.0.0.0" Manufacturer="HuntAndPeck" UpgradeCode="e47f0958-e969-481b-af24-6df49fd45ca7">
+    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate />
+
+    <Feature Id="ProductFeature" Title="HuntAndPeck" Level="1">
+      <?if $(sys.BUILDARCH)=x86?>
+      <!--<ComponentGroupRef Id="StartMenuComponents"/> -->
+      <!--#todo-->
+      <!--<ComponentGroupRef Id="Settings"/> -->
+      <!--#todo-->
+      <?endif ?>
+      <ComponentGroupRef Id="Componentsx86" />
+      <ComponentGroupRef Id="Componentsx64"/>
+    </Feature>
+
+    <InstallExecuteSequence>
+      <!--When MSI is 32 bit-->
+      <?if $(sys.BUILDARCH)=x86?>
+      <?endif?>
+    </InstallExecuteSequence>
+  </Product>
+
+  <!--Directory Structure-->
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDERx86" Name="HuntAndPeck" />
+      </Directory>
+      <Directory Id="ProgramFiles64Folder">
+        <Directory Id="INSTALLFOLDERx64" Name="HuntAndPeck">
+        </Directory>
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="Componentsx86" Directory="INSTALLFOLDERx86">
+      <Component Id="HAPx86" Guid="{36C49F2D-4984-48DC-9EFF-B7FDA3BEFDC2}">
+        <File Id="HAPx86EXE" Source="..\HuntAndPeck\bin\Release\hap.exe" KeyPath="yes"/>
+      </Component>
+      <Component Id="CONFIGx86" Guid="{C26B82BA-5932-45B0-9C04-45F4DB217CDA}">
+        <File Id="HAPx86CONFIG" Source="..\HuntAndPeck\bin\Release\hap.exe.config" KeyPath="yes"/>
+      </Component>
+      <Component Id="TASKBARNOTIFICATIONx86" Guid="{A4EBC175-73E2-4E73-A36B-40150F8E5F1C}">
+        <File Id="TASKBARNOTIFICATIONx86DLL" Source="..\HuntAndPeck\bin\Release\Hardcodet.Wpf.TaskbarNotification.dll" KeyPath="yes"/>
+      </Component>
+      <Component Id="NATIVEMETHODSx86" Guid="{18C84E52-676F-4CE2-B4AC-E9E2E6C94C5B}">
+        <File Id="NATIVEMETHODSx86DLL" Source="..\HuntAndPeck\bin\Release\HuntAndPeck.NativeMethods.dll" KeyPath="yes"/>
+      </Component>
+      <Component Id="UIAUTOMATIONCLIENTx86" Guid="{1FB81928-DF06-4A87-A2B1-495F0A85A66B}">
+        <File Id="UIAUTOMATIONCLIENTx86DLL" Source="..\HuntAndPeck\bin\Release\Interop.UIAutomationClient.dll" KeyPath="yes"/>
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="Componentsx64" Directory="INSTALLFOLDERx64">
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/MSI/ReadMe.txt
+++ b/src/MSI/ReadMe.txt
@@ -1,0 +1,1 @@
+This is a ReadMe for HuntAndPeck

--- a/src/NativeMethods/NativeMethods.csproj
+++ b/src/NativeMethods/NativeMethods.csproj
@@ -33,6 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -52,10 +53,10 @@
     <Compile Include="Kernel32.cs" />
     <Compile Include="KeyModifier.cs" />
     <Compile Include="POINT.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />    
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RECT.cs" />
     <Compile Include="User32.cs" />
-  </ItemGroup>  
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NativeMethods/NativeMethods.csproj
+++ b/src/NativeMethods/NativeMethods.csproj
@@ -52,10 +52,10 @@
     <Compile Include="Kernel32.cs" />
     <Compile Include="KeyModifier.cs" />
     <Compile Include="POINT.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />    
     <Compile Include="RECT.cs" />
     <Compile Include="User32.cs" />
-  </ItemGroup>
+  </ItemGroup>  
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NativeMethods/app.config
+++ b/src/NativeMethods/app.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <configSections>
+    </configSections>
+</configuration>


### PR DESCRIPTION
Installing HuntAndPeck and defining keyboard shortcuts in %AppData% seemed to go hand-in-hand since many applications do both, not just 1.  If this makes more sense as 2 separate  pull requests I can redo this as 2.  
An MSI installer is much more intuitive for non-programmers.  Someone who finds Vimium-style hints useful might experience significant confusion over a portable zipped application.
Defining the keyboard shortcuts through XML is useful when they conflict with shortcuts for the active program, such as Visual Studio.  