### PR TITLE
Feat/add changing font size in tray menu Ref #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ NOTE: hunt-n-peck is no longer maintained, please consider one of the various fo
 
 https://github.com/zsims/hunt-and-peck/releases/download/release%2F1.6/HuntAndPeck-1.6.zip
 
+# How to change font size
+
+Find the application icon in tray, click right mouse button, select `Options`, then use the `FontSize` menu to change the font size.
+
 # Screenshots
 
 ![ScreenShot](https://raw.github.com/zsims/hunt-n-peck/master/screenshots/explorer.png)

--- a/src/HuntAndPeck/App.config
+++ b/src/HuntAndPeck/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
     </startup>
 </configuration>

--- a/src/HuntAndPeck/HuntAndPeck.csproj
+++ b/src/HuntAndPeck/HuntAndPeck.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HuntAndPeck</RootNamespace>
     <AssemblyName>hap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -184,9 +184,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5">
+    <BootstrapperPackage Include=".NETFramework,Version=v4.5.1">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.5.1 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/src/HuntAndPeck/Properties/Settings.Designer.cs
+++ b/src/HuntAndPeck/Properties/Settings.Designer.cs
@@ -9,18 +9,31 @@
 //------------------------------------------------------------------------------
 
 namespace HuntAndPeck.Properties {
-    
-    
+
+
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
-        
+
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-        
+
         public static Settings Default {
             get {
                 return defaultInstance;
             }
         }
+
+    [global::System.Configuration.UserScopedSettingAttribute()]
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    [global::System.Configuration.DefaultSettingValueAttribute("14")]
+    public string FontSize {
+        get {
+            return ((string)(this["FontSize"]));
+        }
+        set {
+            this["FontSize"] = value;
+        }
+    }
+
     }
 }

--- a/src/HuntAndPeck/Properties/Settings.settings
+++ b/src/HuntAndPeck/Properties/Settings.settings
@@ -3,5 +3,9 @@
   <Profiles>
     <Profile Name="(Default)" />
   </Profiles>
-  <Settings />
+  <Settings>
+    <Setting Name="FontSize" Type="System.String" Scope="User">
+      <Value Profile="(Default)">14</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/src/HuntAndPeck/ViewModels/HintViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/HintViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using HuntAndPeck.Models;
+using HuntAndPeck.Properties;
 
 namespace HuntAndPeck.ViewModels
 {
@@ -6,10 +7,12 @@ namespace HuntAndPeck.ViewModels
     {
         private string _label;
         private bool _active;
+        private string _fontSizeReadValue;
 
         public HintViewModel(Hint hint)
         {
             Hint = hint;
+            FontSizeReadValue = Settings.Default.FontSize;
         }
 
         public Hint Hint { get; set; }
@@ -24,6 +27,12 @@ namespace HuntAndPeck.ViewModels
         {
             get { return _label; }
             set { _label = value; NotifyOfPropertyChange(); }
+        }
+
+        public string FontSizeReadValue
+        {
+            get { return _fontSizeReadValue; }
+            set { _fontSizeReadValue = value; NotifyOfPropertyChange(); }
         }
     }
 }

--- a/src/HuntAndPeck/ViewModels/OptionsViewModel.cs
+++ b/src/HuntAndPeck/ViewModels/OptionsViewModel.cs
@@ -1,12 +1,56 @@
-﻿namespace HuntAndPeck.ViewModels
+﻿using HuntAndPeck.Properties;
+using System;
+using System.ComponentModel;
+using System.Windows;
+
+namespace HuntAndPeck.ViewModels
 {
-    internal class OptionsViewModel
+    internal class OptionsViewModel : INotifyPropertyChanged
     {
         public OptionsViewModel()
         {
             DisplayName = "Options";
+            FontSize = Settings.Default.FontSize;
+            Settings.Default.PropertyChanged += OnSettingsPropertyChanged;
         }
 
         public string DisplayName { get; set; }
+
+        private string _fontSize;
+        public string FontSize
+        // Assign the font size value to a variable and update it every time user 
+        // changes the option in tray menu
+        {
+            get { return _fontSize; }
+            set
+            {
+                if (_fontSize != value)
+                {
+                    _fontSize = value;
+                    OnPropertyChanged("FontSize");
+                    Settings.Default.FontSize = value;
+                    Settings.Default.Save();
+                }
+            }
+        }
+
+
+        private void OnSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "FontSize")
+            {
+                FontSize = Settings.Default.FontSize;
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
     }
 }

--- a/src/HuntAndPeck/Views/OptionsView.xaml
+++ b/src/HuntAndPeck/Views/OptionsView.xaml
@@ -22,5 +22,31 @@
                 </Grid>
             </TabItem.Content>
         </TabItem>
+        <TabItem Header="FontSize">
+            <TabItem.Content>
+                <StackPanel>
+                    <Label Content="Font Size" />
+                    <ComboBox SelectedValue="{Binding FontSize}" SelectedValuePath="Content">
+                        <ComboBoxItem>8</ComboBoxItem>
+                        <ComboBoxItem>9</ComboBoxItem>
+                        <ComboBoxItem>10</ComboBoxItem>
+                        <ComboBoxItem>11</ComboBoxItem>
+                        <ComboBoxItem>12</ComboBoxItem>
+                        <ComboBoxItem>13</ComboBoxItem>
+                        <ComboBoxItem>14</ComboBoxItem>
+                        <ComboBoxItem>15</ComboBoxItem>
+                        <ComboBoxItem>16</ComboBoxItem>
+                        <ComboBoxItem>17</ComboBoxItem>
+                        <ComboBoxItem>18</ComboBoxItem>
+                        <ComboBoxItem>19</ComboBoxItem>
+                        <ComboBoxItem>20</ComboBoxItem>
+                        <ComboBoxItem>21</ComboBoxItem>
+                        <ComboBoxItem>22</ComboBoxItem>
+                        <ComboBoxItem>23</ComboBoxItem>
+                        <ComboBoxItem>24</ComboBoxItem>
+                    </ComboBox>
+                </StackPanel>
+            </TabItem.Content>
+        </TabItem>
     </TabControl>
 </Window>

--- a/src/HuntAndPeck/Views/OverlayView.xaml
+++ b/src/HuntAndPeck/Views/OverlayView.xaml
@@ -49,7 +49,7 @@
                             </Rectangle.Fill>
                         </Rectangle>-->
                         <Viewbox StretchDirection="DownOnly" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="1 1 0 0" Width="{Binding Hint.BoundingRectangle.Width}" Height="{Binding Hint.BoundingRectangle.Height}">
-                            <TextBlock Text="{Binding Label}" FontFamily="Helvetica, Arial" FontWeight="Bold" FontSize="12" Style="{StaticResource HintStyle}">
+                            <TextBlock Text="{Binding Label}" FontFamily="Helvetica, Arial" FontWeight="Bold" FontSize="{Binding FontSizeReadValue}" Style="{StaticResource HintStyle}">
                             </TextBlock>
                         </Viewbox>
                     </Grid>

--- a/src/NativeMethods/NativeMethods.csproj
+++ b/src/NativeMethods/NativeMethods.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HuntAndPeck.NativeMethods</RootNamespace>
     <AssemblyName>HuntAndPeck.NativeMethods</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>


### PR DESCRIPTION
Now changing font size is possible by using the tray options. Program remembers the option after closing.

The download link for binaries is:
https://github.com/adrianhajdukiewicz1/hunt-and-peck/releases/download/release%2F1.7/HuntAndPeck-1.7.zip
(tested on Windows 10)

- [x] update README
- [x] add new version of binaries

In my opinion it is ready to merge.